### PR TITLE
Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,14 @@ your 5 pacman lives.
 library(remotes)
 
 # Packages required for interactive rendering
-remotes::install_githb("coolbutuseless/eventloop")
-remotes::install_githb("coolbutuseless/nara")
+remotes::install_github("coolbutuseless/eventloop")
+remotes::install_github("coolbutuseless/nara")
 
 # Grab a copy of the pacman game code
 x <- remotes::remote_download(remotes::github_remote('coolbutuseless/pacman'))
 untar(x, exdir = 'pacman')
 setwd('pacman')
+setwd(dir())
 source('game.R')
 ```
 


### PR DESCRIPTION
It seems that there is another directory inside `pacman`:
```
❯ ls pacman
coolbutuseless-pacman-919eb65/

❯ ls pacman/coolbutuseless-pacman-919eb65
LICENSE.txt	board.R		image/		sound.R		video/
README.md	game.R		sound/		sprites.R
```

This is macOS, but I think it is probably the same on all platforms.